### PR TITLE
fix typos

### DIFF
--- a/rx.lua
+++ b/rx.lua
@@ -645,7 +645,7 @@ function Observable:distinctUntilChanged(comparator)
     end
 
     local function onError(message)
-      return observer:onError(onError)
+      return observer:onError(message)
     end
 
     local function onCompleted()
@@ -707,7 +707,7 @@ function Observable:filter(predicate)
     end
 
     local function onCompleted()
-      return observer:onCompleted(e)
+      return observer:onCompleted()
     end
 
     return self:subscribe(onNext, onError, onCompleted)
@@ -729,7 +729,7 @@ function Observable:find(predicate)
     end
 
     local function onError(message)
-      return observer:onError(e)
+      return observer:onError(message)
     end
 
     local function onCompleted()
@@ -1011,7 +1011,7 @@ function Observable:reject(predicate)
     end
 
     local function onCompleted()
-      return observer:onCompleted(e)
+      return observer:onCompleted()
     end
 
     return self:subscribe(onNext, onError, onCompleted)

--- a/src/operators/distinctUntilChanged.lua
+++ b/src/operators/distinctUntilChanged.lua
@@ -21,7 +21,7 @@ function Observable:distinctUntilChanged(comparator)
     end
 
     local function onError(message)
-      return observer:onError(onError)
+      return observer:onError(message)
     end
 
     local function onCompleted()

--- a/src/operators/filter.lua
+++ b/src/operators/filter.lua
@@ -19,7 +19,7 @@ function Observable:filter(predicate)
     end
 
     local function onCompleted()
-      return observer:onCompleted(e)
+      return observer:onCompleted()
     end
 
     return self:subscribe(onNext, onError, onCompleted)

--- a/src/operators/find.lua
+++ b/src/operators/find.lua
@@ -16,7 +16,7 @@ function Observable:find(predicate)
     end
 
     local function onError(message)
-      return observer:onError(e)
+      return observer:onError(message)
     end
 
     local function onCompleted()

--- a/src/operators/reject.lua
+++ b/src/operators/reject.lua
@@ -20,7 +20,7 @@ function Observable:reject(predicate)
     end
 
     local function onCompleted()
-      return observer:onCompleted(e)
+      return observer:onCompleted()
     end
 
     return self:subscribe(onNext, onError, onCompleted)


### PR DESCRIPTION
noticed a couple apparent typos/bugs in a few of the operators. Might be worth modifying you test runner to throw an error if code tries to access a global that does not exist