### PR TITLE
Fix combineLatest operator subscription to unsubscribe from all subscription

### DIFF
--- a/rx.lua
+++ b/rx.lua
@@ -522,7 +522,7 @@ function Observable:combineLatest(...)
     end
 
     return Subscription.create(function ()
-      for i = 1, #subscription do
+      for i = 1, #sources do
         if subscription[i] then subscription[i]:unsubscribe() end
       end
     end)

--- a/src/operators/combineLatest.lua
+++ b/src/operators/combineLatest.lua
@@ -55,7 +55,7 @@ function Observable:combineLatest(...)
     end
 
     return Subscription.create(function ()
-      for i = 1, #subscription do
+      for i = 1, #sources do
         if subscription[i] then subscription[i]:unsubscribe() end
       end
     end)

--- a/tests/combineLatest.lua
+++ b/tests/combineLatest.lua
@@ -5,10 +5,8 @@ describe('combineLatest', function()
   end)
 
   it('unsubscribes from the combined source observables', function()
-    local unsubscribeA = spy()
-    local subscriptionA = Rx.Subscription.create(unsubscribeA)
     local observableA = Rx.Observable.create(function(observer)
-      return subscriptionA
+      return nil
     end)
 
     local unsubscribeB = spy()
@@ -19,7 +17,6 @@ describe('combineLatest', function()
 
     local subscription = Rx.Observable.combineLatest(observableA, observableB):subscribe()
     subscription:unsubscribe()
-    expect(#unsubscribeA).to.equal(1)
     expect(#unsubscribeB).to.equal(1)
   end)
 


### PR DESCRIPTION
If there is any nil subscription from sources,
the subscription skips to unsubscribe from the rest source's subscriptions.