### PR TITLE
Fix subject unsubscribe index error

### DIFF
--- a/rx.lua
+++ b/rx.lua
@@ -1984,8 +1984,9 @@ end
 -- @arg {*...} values
 function Subject:onNext(...)
   if not self.stopped then
-    for i = 1, #self.observers do
-      self.observers[i]:onNext(...)
+    local observers = {util.unpack(self.observers)}
+    for i = 1, #observers do
+      observers[i]:onNext(...)
     end
   end
 end
@@ -1994,8 +1995,9 @@ end
 -- @arg {string=} message - A string describing what went wrong.
 function Subject:onError(message)
   if not self.stopped then
-    for i = 1, #self.observers do
-      self.observers[i]:onError(message)
+    local observers = {util.unpack(self.observers)}
+    for i = 1, #observers do
+      observers[i]:onError(message)
     end
 
     self.stopped = true
@@ -2005,8 +2007,9 @@ end
 --- Signal to all Observers that the Subject will not produce any more values.
 function Subject:onCompleted()
   if not self.stopped then
-    for i = 1, #self.observers do
-      self.observers[i]:onCompleted()
+    local observers = {util.unpack(self.observers)}
+    for i = 1, #observers do
+      observers[i]:onCompleted()
     end
 
     self.stopped = true

--- a/src/subjects/subject.lua
+++ b/src/subjects/subject.lua
@@ -52,8 +52,9 @@ end
 -- @arg {*...} values
 function Subject:onNext(...)
   if not self.stopped then
-    for i = 1, #self.observers do
-      self.observers[i]:onNext(...)
+    local observers = {util.unpack(self.observers)}
+    for i = 1, #observers do
+      observers[i]:onNext(...)
     end
   end
 end
@@ -62,8 +63,9 @@ end
 -- @arg {string=} message - A string describing what went wrong.
 function Subject:onError(message)
   if not self.stopped then
-    for i = 1, #self.observers do
-      self.observers[i]:onError(message)
+    local observers = {util.unpack(self.observers)}
+    for i = 1, #observers do
+      observers[i]:onError(message)
     end
 
     self.stopped = true
@@ -73,8 +75,9 @@ end
 --- Signal to all Observers that the Subject will not produce any more values.
 function Subject:onCompleted()
   if not self.stopped then
-    for i = 1, #self.observers do
-      self.observers[i]:onCompleted()
+    local observers = {util.unpack(self.observers)}
+    for i = 1, #observers do
+      observers[i]:onCompleted()
     end
 
     self.stopped = true


### PR DESCRIPTION
When an observer unsubscribe a subject by itself, it reduces subject's `self.observers` length during the loop, which causes accessing array out of bounds. For example:
```lua
local rx = require("rx.lua")

local subject = rx.Subject.create()

local sub_a
sub_a = subject:subscribe(function(n)
  print("Sub A: " .. n)
  if (n == 5) then
    sub_a:unsubscribe()
    print("Sub A: Unsubcribed")
  end
end)

local sub_b
sub_b = subject:subscribe(function(n)
  print("Sub B: " .. n)
  if (n == 10) then
    sub_b:unsubscribe()
    print("Sub B: Unsubcribed")
  end
end)

for i = 1, 15 do
  subject:onNext(i)
end
```
```
Sub A: 1
Sub B: 1
Sub A: 2
Sub B: 2
Sub A: 3
Sub B: 3
Sub A: 4
Sub B: 4
Sub A: 5
Sub A: Unsubcribed

rx.lua:1988: attempt to index a nil value (field '?')
stack traceback:
        lua.lua:1988: in method 'onNext'
        test.lua:24: in main chunk
```
The fix is to create a copy of the array before the loop. The output is:
```
Sub A: 1
Sub B: 1
Sub A: 2
Sub B: 2
Sub A: 3
Sub B: 3
Sub A: 4
Sub B: 4
Sub A: 5
Sub A: Unsubcribed
Sub B: 5
Sub B: 6
Sub B: 7
Sub B: 8
Sub B: 9
Sub B: 10
Sub B: Unsubcribed
```
