### PR TITLE
Rename 'continue' -> '_continue'.

### DIFF
--- a/rx.lua
+++ b/rx.lua
@@ -450,12 +450,12 @@ function Observable:catch(handler)
         return observer:onCompleted()
       end
 
-      local success, continue = pcall(handler, e)
-      if success and continue then
+      local success, _continue = pcall(handler, e)
+      if success and _continue then
         if subscription then subscription:unsubscribe() end
-        continue:subscribe(observer)
+        _continue:subscribe(observer)
       else
-        observer:onError(success and e or continue)
+        observer:onError(success and e or _continue)
       end
     end
 

--- a/src/operators/catch.lua
+++ b/src/operators/catch.lua
@@ -21,12 +21,12 @@ function Observable:catch(handler)
         return observer:onCompleted()
       end
 
-      local success, continue = pcall(handler, e)
-      if success and continue then
+      local success, _continue = pcall(handler, e)
+      if success and _continue then
         if subscription then subscription:unsubscribe() end
-        continue:subscribe(observer)
+        _continue:subscribe(observer)
       else
-        observer:onError(success and e or continue)
+        observer:onError(success and e or _continue)
       end
     end
 


### PR DESCRIPTION
This fixes compatibility with Lua modifications that support the `continue` statement (e.g. in Garry's Mod).