### PR TITLE
observable: allow dumping multiple values without a formatter

### DIFF
--- a/rx.lua
+++ b/rx.lua
@@ -283,9 +283,13 @@ end
 -- @arg {function=tostring} formatter - A function that formats one or more values to be printed.
 function Observable:dump(name, formatter)
   name = name and (name .. ' ') or ''
-  formatter = formatter or tostring
 
-  local onNext = function(...) print(name .. 'onNext: ' .. formatter(...)) end
+  local onNext
+  if formatter then
+    onNext = function(...) print(name .. 'onNext: ' .. formatter(...)) end
+  else
+    onNext = function(...) print(name .. 'onNext: ', ...) end
+  end
   local onError = function(e) print(name .. 'onError: ' .. e) end
   local onCompleted = function() print(name .. 'onCompleted') end
 

--- a/src/observable.lua
+++ b/src/observable.lua
@@ -188,9 +188,13 @@ end
 -- @arg {function=tostring} formatter - A function that formats one or more values to be printed.
 function Observable:dump(name, formatter)
   name = name and (name .. ' ') or ''
-  formatter = formatter or tostring
 
-  local onNext = function(...) print(name .. 'onNext: ' .. formatter(...)) end
+  local onNext
+  if formatter then
+    onNext = function(...) print(name .. 'onNext: ' .. formatter(...)) end
+  else
+    onNext = function(...) print(name .. 'onNext: ', ...) end
+  end
   local onError = function(e) print(name .. 'onError: ' .. e) end
   local onCompleted = function() print(name .. 'onCompleted') end
 


### PR DESCRIPTION
Currently, Observable:dump does not work well with multiple values and no
formatter.  We can skip tostring and just unpack the values into print in
order to improve the behavior.