### PR TITLE
Clear luacheck warnings

### DIFF
--- a/rx.lua
+++ b/rx.lua
@@ -5,7 +5,7 @@
 local util = {}
 
 util.pack = table.pack or function(...) return { n = select('#', ...), ... } end
-util.unpack = table.unpack or unpack
+util.unpack = table.unpack or _G.unpack
 util.eq = function(x, y) return x == y end
 util.noop = function() end
 util.identity = function(x) return x end
@@ -133,7 +133,7 @@ end
 
 --- Returns an Observable that never produces values and never completes.
 function Observable.never()
-  return Observable.create(function(observer) end)
+  return Observable.create(function() end)
 end
 
 --- Returns an Observable that immediately produces an error.
@@ -657,8 +657,6 @@ function Observable:debounce(time, scheduler)
 
     local function wrap(key)
       return function(...)
-        local value = util.pack(...)
-
         if debounced[key] then
           debounced[key]:unsubscribe()
         end
@@ -1829,6 +1827,7 @@ function Observable.zip(...)
         table.insert(values[i], value)
         values[i].n = values[i].n + 1
 
+        -- luacheck: ignore i
         local ready = true
         for i = 1, count do
           if values[i].n == 0 then
@@ -1890,6 +1889,7 @@ end
 --- Schedules a function to be run on the scheduler. It is executed immediately.
 -- @arg {function} action - The function to execute.
 function ImmediateScheduler:schedule(action)
+  local _ = self
   action()
 end
 
@@ -1993,8 +1993,8 @@ end
 -- @arg {number=0} delay - The delay, in milliseconds.
 -- @returns {Subscription}
 function TimeoutScheduler:schedule(action, delay, ...)
+  local _ = self
   local timer = require 'timer'
-  local subscription
   local handle = timer.setTimeout(delay, action, ...)
   return Subscription.create(function()
     timer.clearTimeout(handle)

--- a/src/observable.lua
+++ b/src/observable.lua
@@ -1,3 +1,4 @@
+local Observer = require 'observer'
 local util = require 'util'
 
 --- @class Observable
@@ -38,7 +39,7 @@ end
 
 --- Returns an Observable that never produces values and never completes.
 function Observable.never()
-  return Observable.create(function(observer) end)
+  return Observable.create(function() end)
 end
 
 --- Returns an Observable that immediately produces an error.

--- a/src/operators/amb.lua
+++ b/src/operators/amb.lua
@@ -1,4 +1,5 @@
 local Observable = require 'observable'
+local Subscription = require 'subscription'
 
 --- Given a set of Observables, produces values from only the first one to produce a value.
 -- @arg {Observable...} observables

--- a/src/operators/combineLatest.lua
+++ b/src/operators/combineLatest.lua
@@ -1,4 +1,5 @@
 local Observable = require 'observable'
+local Subscription = require 'subscription'
 local util = require 'util'
 
 --- Returns a new Observable that runs a combinator function on the most recent values from a set

--- a/src/operators/debounce.lua
+++ b/src/operators/debounce.lua
@@ -16,8 +16,6 @@ function Observable:debounce(time, scheduler)
 
     local function wrap(key)
       return function(...)
-        local value = util.pack(...)
-
         if debounced[key] then
           debounced[key]:unsubscribe()
         end

--- a/src/operators/flatten.lua
+++ b/src/operators/flatten.lua
@@ -1,5 +1,5 @@
 local Observable = require 'observable'
-local util = require 'util'
+local Subscription = require 'subscription'
 
 --- Returns a new Observable that subscribes to the Observables produced by the original and
 -- produces their values.

--- a/src/operators/merge.lua
+++ b/src/operators/merge.lua
@@ -1,4 +1,5 @@
 local Observable = require 'observable'
+local Subscription = require 'subscription'
 
 --- Returns a new Observable that produces the values produced by all the specified Observables in
 -- the order they are produced.

--- a/src/operators/sample.lua
+++ b/src/operators/sample.lua
@@ -1,4 +1,5 @@
 local Observable = require 'observable'
+local Subscription = require 'subscription'
 local util = require 'util'
 
 --- Returns a new Observable that produces its most recent value every time the specified observable

--- a/src/operators/switch.lua
+++ b/src/operators/switch.lua
@@ -1,4 +1,5 @@
 local Observable = require 'observable'
+local Subscription = require 'subscription'
 
 --- Given an Observable that produces Observables, returns an Observable that produces the values
 -- produced by the most recently produced Observable.

--- a/src/operators/with.lua
+++ b/src/operators/with.lua
@@ -1,4 +1,5 @@
 local Observable = require 'observable'
+local Subscription = require 'subscription'
 local util = require 'util'
 
 --- Returns an Observable that produces values from the original along with the most recently

--- a/src/operators/zip.lua
+++ b/src/operators/zip.lua
@@ -1,4 +1,5 @@
 local Observable = require 'observable'
+local Subscription = require 'subscription'
 local util = require 'util'
 
 --- Returns an Observable that merges the values produced by the source Observables by grouping them
@@ -26,6 +27,7 @@ function Observable.zip(...)
         table.insert(values[i], value)
         values[i].n = values[i].n + 1
 
+        -- luacheck: ignore i
         local ready = true
         for i = 1, count do
           if values[i].n == 0 then

--- a/src/schedulers/immediatescheduler.lua
+++ b/src/schedulers/immediatescheduler.lua
@@ -15,6 +15,7 @@ end
 --- Schedules a function to be run on the scheduler. It is executed immediately.
 -- @arg {function} action - The function to execute.
 function ImmediateScheduler:schedule(action)
+  local _ = self
   action()
 end
 

--- a/src/schedulers/timeoutscheduler.lua
+++ b/src/schedulers/timeoutscheduler.lua
@@ -1,4 +1,5 @@
 local Subscription = require 'subscription'
+local util = require 'util'
 
 --- @class TimeoutScheduler
 -- @description A scheduler that uses luvit's timer library to schedule events on an event loop.
@@ -17,8 +18,8 @@ end
 -- @arg {number=0} delay - The delay, in milliseconds.
 -- @returns {Subscription}
 function TimeoutScheduler:schedule(action, delay, ...)
+  local _ = self
   local timer = require 'timer'
-  local subscription
   local handle = timer.setTimeout(delay, action, ...)
   return Subscription.create(function()
     timer.clearTimeout(handle)

--- a/src/util.lua
+++ b/src/util.lua
@@ -1,7 +1,7 @@
 local util = {}
 
 util.pack = table.pack or function(...) return { n = select('#', ...), ... } end
-util.unpack = table.unpack or unpack
+util.unpack = table.unpack or _G.unpack
 util.eq = function(x, y) return x == y end
 util.noop = function() end
 util.identity = function(x) return x end

--- a/tools/build.lua
+++ b/tools/build.lua
@@ -136,6 +136,6 @@ end
 local file = io.open(destination, 'w')
 
 if file then
-  file:write(table.concat(components, ''))
+  file:write(table.concat(components, ''), "\n")
   file:close()
 end


### PR DESCRIPTION
this pr clear the luacheck warnings for rx.lua:
- add several missing subscription module require
- cleanup "unused variable" warnings in several place
- remove a duplicate util.pack(...) in `Observable:debounce`
- disable a "shallow variable" warning for iterator `i`
- add a extra "\n" (for Vim) to end of rx.lua file